### PR TITLE
.dockerignoreを作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+select_list


### PR DESCRIPTION
.dockerignoreを作成し、select_listと記載することでdockerのbuild時にselect_listを無視する様に修正