### PR TITLE
リビジョンが1であったとしても研究対象とするように修正

### DIFF
--- a/processing_file/removalData.py
+++ b/processing_file/removalData.py
@@ -13,8 +13,10 @@ def removal_file(filepath):
         removal = 1
     elif not json_load['messages']: # コメントがなされているか
         removal = 1
+    '''
     elif sandwich_message(json_load['messages']): # リビジョン更新の前後にコメントがなされているか
         removal = 1
+    '''
 
     return removal, json_load
 


### PR DESCRIPTION
修正要求がなされた後に，開発者がその修正要求に対して問題がないことなどを説明した場合に
同一リビジョン内で修正確認コメント(例：LGTMなど)が為される場合があるため，
リビジョンが1であったとしても研究対象とするように変更