### PR TITLE
BertEvaluate.pyの修正

### DIFF
--- a/processing_file/BERT/BertmodelCreate.py
+++ b/processing_file/BERT/BertmodelCreate.py
@@ -71,3 +71,6 @@ trainer = Trainer(
 
 # トレーニング開始
 trainer.train()
+
+# トレーニング完了後に最終的なモデルを保存
+trainer.save_model()


### PR DESCRIPTION
BertEvaluate.pyにおいて元のチェックリストを用いて処理できる様に修正完了
下記機能を追加完了
- 元のチェックリストファイルに再現率，適合率，f1，予測値を追加
- 後半1割のデータを用いてテストを行う
- 最終的に作成されたモデルを利用できるように修正
    - 元々はチェックポイント500で動作するようになっていた
    - 最終的に作成されたモデルを保存するようにBertmodelCreate.pyもやや修正