### PR TITLE
owner名の表示とパスの修正

### DIFF
--- a/processing_file/checkList/AddOwner.py
+++ b/processing_file/checkList/AddOwner.py
@@ -26,9 +26,7 @@ def FindOwner(CheckList_df):
             jsonFile = json.load(f)
         
         # 開発者名をリストに追加
-        owner.append({
-            jsonFile['owner']['name'].lstrip('{\'').rstrip('\'}')
-        })
+        owner.append(jsonFile['owner']['name'])
     return owner
 
 def main():
@@ -41,6 +39,7 @@ def main():
     CheckList_df.insert(loc = 5, column='owner', value=owner)
 
     # ownerを追加したチェックリストの書き出し
-    CheckList_df.to_csv('/Users/haruto-k/Desktop/checkList.csv')
+    Write_CheckList_path = '/Users/haruto-k/research/select_list/chekList/alradyStart/checkList.csv'
+    CheckList_df.to_csv(Write_CheckList_path)
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- owner名が{'haruto'}のように表示されるようになっていたため，適切に表示されるように修正
- 出力のパスがDesktopだったため，チェックリストファイルに保存されるようにパスの修正