### PR TITLE
BertCrossValidaiton.pyで途中のコンマが欠落していたため追加

### DIFF
--- a/processing_file/BERT/BertCrossValidation.py
+++ b/processing_file/BERT/BertCrossValidation.py
@@ -61,7 +61,7 @@ def train_and_evaluate(train_dataset, val_dataset, test_dataset, fold):
         weight_decay=0.01,
         logging_dir=f'./logs_fold_{fold}',  # ログ出力先
         logging_steps=10,
-        evaluation_strategy="epoch"
+        evaluation_strategy="epoch",
         save_strategy="epoch"
     )
     # トレーナーの設定


### PR DESCRIPTION
コードの途中にコンマが欠落しており，動作がしないようになっていたため，修正．