### PR TITLE
DefinitionAssociateRocal.pyにおいてowner呼び出し時のエラーを修正

### DIFF
--- a/processing_file/associate/DefinitionAssociateRocal.py
+++ b/processing_file/associate/DefinitionAssociateRocal.py
@@ -49,7 +49,7 @@ def FindAchieve(ReviewCommentsFile):
     for CommentData in ReviewCommentsFile['messages']:
 
         # PR実装者によるコメントでないか確認
-        if CommentData.get('author', {}).get('name', '') == ReviewCommentsFile['owner']['name']:
+        if CommentData.get('author', {}).get('name', '') == ReviewCommentsFile.get('owner', {}).get('name', ''):
 
             # PR実装者のコメントは対象にしない
             continue
@@ -76,7 +76,7 @@ def FindRequest(ReviewCommentsFile, Model, Tokenizer):
     for CommentData in ReviewCommentsFile['messages']:
         
         # PR実装者によるコメントでないか確認
-        if CommentData.get('author', {}).get('name', '') == ReviewCommentsFile['owner']['name']:
+        if CommentData.get('author', {}).get('name', '') == ReviewCommentsFile.get('owner', {}).get('name', ''):
 
             # PR実装者のコメントは対象にしない
             continue


### PR DESCRIPTION
DefinitionAssociateRocal.pyにてowner名の呼び出し時に
owner名が存在しない場合にエラーが発生するため(発生したため)，存在しない場合のための処理を追加．