### PR TITLE
交差検証用のファイルが全て評価値の平均値を算出していたため，中央値を算出するように修正

### DIFF
--- a/processing_file/BERT/cross_validation.py
+++ b/processing_file/BERT/cross_validation.py
@@ -124,10 +124,11 @@ for dfRow in  range(len(df)):
 
 
 # 元のデータフレームに予測結果を組み込む
-df.insert(loc = 0, column='precision', value=results_df['precision'].mean())
-df.insert(loc = 1, column='recall', value=results_df['recall'].mean())
-df.insert(loc = 2, column='f1', value=results_df['f1'].mean())
+df.insert(loc = 0, column='precision', value=results_df['precision'].median())
+df.insert(loc = 1, column='recall', value=results_df['recall'].median())
+df.insert(loc = 2, column='f1', value=results_df['f1'].median())
 df.insert(loc = 12, column='予測', value=sorted_preds)
 df = df.rename(columns={'text': 'comment', 'label': '修正要求'})
 
 df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/checklist_result.csv', index=False, encoding='utf_8_sig')
+results_df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/value/default.csv', index=False, encoding="utf_8_sig")

--- a/processing_file/BERT/label_cross_validation/minus_1.py
+++ b/processing_file/BERT/label_cross_validation/minus_1.py
@@ -131,10 +131,11 @@ for dfRow in range(len(df)):
         sorted_preds[dfRow] = '予測なし'  # 予測がない場合にデフォルト値を設定
 
 # 元のデータフレームに予測結果を組み込む
-df.insert(loc = 0, column='precision', value=results_df['precision'].mean())
-df.insert(loc = 1, column='recall', value=results_df['recall'].mean())
-df.insert(loc = 2, column='f1', value=results_df['f1'].mean())
+df.insert(loc = 0, column='precision', value=results_df['precision'].median())
+df.insert(loc = 1, column='recall', value=results_df['recall'].median())
+df.insert(loc = 2, column='f1', value=results_df['f1'].median())
 df.insert(loc = 12, column='予測', value=sorted_preds)
 df = df.rename(columns={'text': 'comment', 'label': '修正要求'})
 
 df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/label/minus_1.csv', index=False, encoding='utf_8_sig')
+results_df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/value/minus_1.csv', index=False, encoding="utf_8_sig")

--- a/processing_file/BERT/label_cross_validation/minus_2.py
+++ b/processing_file/BERT/label_cross_validation/minus_2.py
@@ -131,10 +131,11 @@ for dfRow in range(len(df)):
         sorted_preds[dfRow] = '予測なし'  # 予測がない場合にデフォルト値を設定
 
 # 元のデータフレームに予測結果を組み込む
-df.insert(loc = 0, column='precision', value=results_df['precision'].mean())
-df.insert(loc = 1, column='recall', value=results_df['recall'].mean())
-df.insert(loc = 2, column='f1', value=results_df['f1'].mean())
+df.insert(loc = 0, column='precision', value=results_df['precision'].median())
+df.insert(loc = 1, column='recall', value=results_df['recall'].median())
+df.insert(loc = 2, column='f1', value=results_df['f1'].median())
 df.insert(loc = 12, column='予測', value=sorted_preds)
 df = df.rename(columns={'text': 'comment', 'label': '修正要求'})
 
 df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/label/minus_2.csv', index=False, encoding='utf_8_sig')
+results_df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/value/minus_2.csv', index=False, encoding="utf_8_sig")

--- a/processing_file/BERT/label_cross_validation/plus_1.py
+++ b/processing_file/BERT/label_cross_validation/plus_1.py
@@ -131,10 +131,11 @@ for dfRow in range(len(df)):
         sorted_preds[dfRow] = '予測なし'  # 予測がない場合にデフォルト値を設定
 
 # 元のデータフレームに予測結果を組み込む
-df.insert(loc = 0, column='precision', value=results_df['precision'].mean())
-df.insert(loc = 1, column='recall', value=results_df['recall'].mean())
-df.insert(loc = 2, column='f1', value=results_df['f1'].mean())
+df.insert(loc = 0, column='precision', value=results_df['precision'].median())
+df.insert(loc = 1, column='recall', value=results_df['recall'].median())
+df.insert(loc = 2, column='f1', value=results_df['f1'].median())
 df.insert(loc = 12, column='予測', value=sorted_preds)
 df = df.rename(columns={'text': 'comment', 'label': '修正要求'})
 
 df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/label/plus_1.csv', index=False, encoding='utf_8_sig')
+results_df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/value/plus_1.csv', index=False, encoding="utf_8_sig")

--- a/processing_file/BERT/label_cross_validation/plus_2.py
+++ b/processing_file/BERT/label_cross_validation/plus_2.py
@@ -131,10 +131,11 @@ for dfRow in range(len(df)):
         sorted_preds[dfRow] = '予測なし'  # 予測がない場合にデフォルト値を設定
 
 # 元のデータフレームに予測結果を組み込む
-df.insert(loc = 0, column='precision', value=results_df['precision'].mean())
-df.insert(loc = 1, column='recall', value=results_df['recall'].mean())
-df.insert(loc = 2, column='f1', value=results_df['f1'].mean())
+df.insert(loc = 0, column='precision', value=results_df['precision'].median())
+df.insert(loc = 1, column='recall', value=results_df['recall'].median())
+df.insert(loc = 2, column='f1', value=results_df['f1'].median())
 df.insert(loc = 12, column='予測', value=sorted_preds)
 df = df.rename(columns={'text': 'comment', 'label': '修正要求'})
 
 df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/label/plus_2.csv', index=False, encoding='utf_8_sig')
+results_df.to_csv('/Users/haruto-k/research/select_list/checkList/alradyStart/value/plus_2.csv', index=False, encoding="utf_8_sig")


### PR DESCRIPTION
5分割交差検証の結果(適合率，再現率，F1値)を平均で算出していたため，
5回駆動した値の平均ではなく中央値を算出するように修正．